### PR TITLE
Legg til endepunkt for å sette security champion uten repo

### DIFF
--- a/src/main/kotlin/com/example/securitychampionapi/controller/SecurityChampionController.kt
+++ b/src/main/kotlin/com/example/securitychampionapi/controller/SecurityChampionController.kt
@@ -41,7 +41,7 @@ class SecurityChampionController(val securityChampionService: SecurityChampionSe
             securityChampionEmail = body.securityChampionEmail,
             modifiedBy = body.modifiedBy
         )
-        return SetSecurityChampionResponse(statusMessage = "SUCCESS")
+        return SetSecurityChampionResponse(status = HttpStatus.OK)
 
     }
 

--- a/src/main/kotlin/com/example/securitychampionapi/controller/SecurityChampionController.kt
+++ b/src/main/kotlin/com/example/securitychampionapi/controller/SecurityChampionController.kt
@@ -1,11 +1,7 @@
 package com.example.securitychampionapi.controller
 
-import com.example.securitychampionapi.controller.models.GetSecurityChampionsBody
-import com.example.securitychampionapi.controller.models.GetSecurityChampionsResponse
-import com.example.securitychampionapi.controller.models.SecurityChampionResponse
-import com.example.securitychampionapi.controller.models.SetSecurityChampionBody
-import com.example.securitychampionapi.controller.models.SetSecurityChampionResponse
-import com.example.securitychampionapi.controller.models.SetSecurityChampionsBody
+
+import com.example.securitychampionapi.controller.models.*
 import com.example.securitychampionapi.service.SecurityChampionService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,7 +16,8 @@ class SecurityChampionController(val securityChampionService: SecurityChampionSe
     @PostMapping("/securityChampion")
     fun getSecurityChampions(@RequestBody body: GetSecurityChampionsBody): GetSecurityChampionsResponse {
         return securityChampionService.getSecurityChampions(body.repositoryNames)
-                .map { SecurityChampionResponse(
+            .map {
+                SecurityChampionResponse(
                     repositoryName = it.repository,
                     securityChampionEmail = it.email
                 )
@@ -30,12 +27,22 @@ class SecurityChampionController(val securityChampionService: SecurityChampionSe
 
     @PostMapping("/setSecurityChampion")
     fun setSecurityChampion(@RequestBody body: SetSecurityChampionBody): SetSecurityChampionResponse {
-         securityChampionService.setSecurityChampion(
+        securityChampionService.setSecurityChampion(
             repositoryName = body.repositoryName,
             securityChampionEmail = body.securityChampionEmail,
-             modifiedBy = body.modifiedBy
+            modifiedBy = body.modifiedBy
         )
         return SetSecurityChampionResponse(status = HttpStatus.OK)
+    }
+
+    @PostMapping("/setSecurityChampionWithNoRepo")
+    fun setSecurityChampionWithNoRepo(@RequestBody body: setSecurityChampionWithNoRepoBody): SetSecurityChampionResponse {
+        securityChampionService.setSecurityChampionWithNoRepo(
+            securityChampionEmail = body.securityChampionEmail,
+            modifiedBy = body.modifiedBy
+        )
+        return SetSecurityChampionResponse(statusMessage = "SUCCESS")
+
     }
 
     @PostMapping("/setSecurityChampions")

--- a/src/main/kotlin/com/example/securitychampionapi/controller/models/setSecurityChampionWithNoRepoBody.kt
+++ b/src/main/kotlin/com/example/securitychampionapi/controller/models/setSecurityChampionWithNoRepoBody.kt
@@ -1,0 +1,7 @@
+package com.example.securitychampionapi.controller.models
+
+data class setSecurityChampionWithNoRepoBody(
+    val securityChampionEmail: String,
+    val modifiedBy: String = "No user provided"
+)
+

--- a/src/main/kotlin/com/example/securitychampionapi/repository/SecurityChampionRepository.kt
+++ b/src/main/kotlin/com/example/securitychampionapi/repository/SecurityChampionRepository.kt
@@ -49,7 +49,11 @@ class SecurityChampionRepository(private val jdbcTemplate: NamedParameterJdbcTem
         )
     }
 
-    fun setSecurityChampions(repositoryNames: List<String>, securityChampionEmail: String, modifiedBy: String): IntArray {
+    fun setSecurityChampions(
+        repositoryNames: List<String>,
+        securityChampionEmail: String,
+        modifiedBy: String
+    ): IntArray {
 
         val query = """
             INSERT INTO securityChampion (email, repository, lastModifiedBy)
@@ -58,11 +62,13 @@ class SecurityChampionRepository(private val jdbcTemplate: NamedParameterJdbcTem
         """
 
 
-        val params =  repositoryNames.map {
-                SecurityChampion (
-                    repository = it,
-                    email = securityChampionEmail,
-                    modifiedBy = modifiedBy) }
+        val params = repositoryNames.map {
+            SecurityChampion(
+                repository = it,
+                email = securityChampionEmail,
+                modifiedBy = modifiedBy
+            )
+        }
 
         val batchParams = SqlParameterSourceUtils.createBatch(params)
         return jdbcTemplate.batchUpdate(query, batchParams)
@@ -79,6 +85,24 @@ class SecurityChampionRepository(private val jdbcTemplate: NamedParameterJdbcTem
             SecurityChampionRowMapper()
         ).toList()
         return result
+    }
+
+    fun setSecurityChampionWithNoRepo(securityChampionEmail: String, modifiedBy: String): Int {
+        val query = """
+            INSERT INTO securityChampion (email, lastModifiedBy)
+            VALUES (:email, :modifiedBy)
+            ON CONFLICT (email) 
+            WHERE repository IS NULL 
+            DO NOTHING
+        """
+        val params = MapSqlParameterSource()
+            .addValue("email", securityChampionEmail)
+            .addValue("modifiedBy", modifiedBy)
+
+        return jdbcTemplate.update(
+            query,
+            params
+        )
     }
 
     class SecurityChampionRowMapper : RowMapper<SecurityChampion> {

--- a/src/main/kotlin/com/example/securitychampionapi/service/SecurityChampionService.kt
+++ b/src/main/kotlin/com/example/securitychampionapi/service/SecurityChampionService.kt
@@ -20,5 +20,10 @@ class SecurityChampionService(private val repository: SecurityChampionRepository
     fun setSecurityChampions(repositoryNames: List<String>, securityChampionEmail: String, modifiedBy: String) =
         repository.setSecurityChampions(repositoryNames, securityChampionEmail, modifiedBy)
 
-    fun getAllRepositoryNamesWithSecurityChampion() = repository.getRepositoriesWithSecurityChampions().map { SecurityChampionResponse(it.repository, it.email) }
+    fun getAllRepositoryNamesWithSecurityChampion() =
+        repository.getRepositoriesWithSecurityChampions().map { SecurityChampionResponse(it.repository, it.email) }
+
+
+    fun setSecurityChampionWithNoRepo(securityChampionEmail: String, modifiedBy: String) =
+        repository.setSecurityChampionWithNoRepo(securityChampionEmail, modifiedBy)
 }

--- a/src/main/resources/db/migration/V4__add__partial__unique__index__for__email.sql
+++ b/src/main/resources/db/migration/V4__add__partial__unique__index__for__email.sql
@@ -1,0 +1,5 @@
+BEGIN;
+CREATE UNIQUE INDEX idx_security_champion_email_null_repo
+    ON securityChampion (email)
+    WHERE repository IS NULL;
+COMMIT;


### PR DESCRIPTION
### Hva ble gjort:

- Lagt til endepunkt for å legge til security champion uten tilhørende repo.

- Oppdatert flyway for å lage unik partial index for å forhindre duplikat av repoløse secchamps. 

Bygger på [denne pr'en](https://github.com/kartverket/security-champion-api/pull/168)