### PR TITLE
Revert "[Test eksterne API definisjoner] Create/update catalog-info.yaml"

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,5 +24,7 @@ spec:
   type: openapi
   lifecycle: production
   owner: skvis
-  definition:
-    $text: https://matrikkel.no/matrikkelapi/wsapi/v1/AdresseServiceWS?WSDL
+  definition: |
+    openapi: "3.0.0"
+    info:
+        title: security-champion-api-api


### PR DESCRIPTION
Reverts kartverket/security-champion-api#175

Feilen var i Backstage. Vi må whiteliste eksterne domener. Denne reverserer yaml endringene tilbake til sånn de var før test PRen.