### PR TITLE
Upgrade runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=eclipse-temurin:24.0.2_12-jdk-alpine-3.22
-ARG IMAGE=eclipse-temurin:24.0.2_12-jre-alpine-3.22
+ARG IMAGE=eclipse-temurin:25.0.1_8-jre-alpine-3.23
 
 FROM ${BUILD_IMAGE} AS build
 COPY . .


### PR DESCRIPTION
# Bakgrunn🔒

Sårbarheter i `eclipse-temurin:24.0.2_12-jre-alpine-3.22`.
<img width="213" height="68" alt="Screenshot 2026-01-20 at 10 53 46" src="https://github.com/user-attachments/assets/42328745-6411-41c4-bd92-33ad839cb038" />

# Løsning🔑

Oppgradere til nyere base image `eclipse-temurin:25.0.1_8-jre-alpine-3.23` i runtime.
<img width="209" height="65" alt="Screenshot 2026-01-20 at 10 54 22" src="https://github.com/user-attachments/assets/b006b991-dcf2-411f-9891-4649c908f9a1" />