### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,8 +9,7 @@ spec:
   lifecycle: production
   owner: skvis
   providesApis:
-    - security-champion-api-api
-  system: utviklerportal
+    - api:default/security-champion-api-api
 
 ---
 apiVersion: backstage.io/v1alpha1
@@ -23,7 +22,13 @@ spec:
   type: openapi
   lifecycle: production
   owner: skvis
-  definition: |
-    openapi: "3.0.0"
-    info:
-        title: security-champion-api-api
+  definition:
+    $text: definition
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: domain-test
+spec:
+  owner: group:default/skvis


### PR DESCRIPTION
catalog-info.yaml now includes more entities

        

        Added entities: 
          name: domain-test, kind: Domain

        All entities in catalog-info.yaml:
        name: security-champion-service, kind: Component

name: security-champion-api-api, kind: API

name: domain-test, kind: Domain 
        
        This PR was created using the Catalog Creator plugin in Backstage.