### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,8 +9,7 @@ spec:
   lifecycle: production
   owner: skvis
   providesApis:
-    - security-champion-api-api
-  system: utviklerportal
+    - api:default/security-champion-api-api
 
 ---
 apiVersion: backstage.io/v1alpha1
@@ -23,7 +22,22 @@ spec:
   type: openapi
   lifecycle: production
   owner: skvis
-  definition: |
-    openapi: "3.0.0"
-    info:
-        title: security-champion-api-api
+  definition:
+    $text: test
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: domain-test
+spec:
+  owner: group:default/skvis
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: resource-test
+spec:
+  type: database
+  owner: group:default/skvis


### PR DESCRIPTION
catalog-info.yaml now includes more entities

        null
        

        Added entities:
          
        name: domain-test, kind: Domain,
        name: resource-test, kind: Resource

        All entities in catalog-info.yaml:
        name: security-champion-service, kind: Component
        name: security-champion-api-api, kind: API
        name: domain-test, kind: Domain
        name: resource-test, kind: Resource 
        
        This PR was created using the Catalog Creator plugin in Backstage.