### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,22 +10,5 @@ spec:
   lifecycle: production
   owner: skvis
   providesApis:
-    - security-champion-api-api
-  system: utviklerportal
-
----
-apiVersion: backstage.io/v1alpha1
-kind: API
-metadata:
-  name: security-champion-api-api
-  title: security champion api
-  tags:
-    - internal
-spec:
-  type: openapi
-  lifecycle: production
-  owner: skvis
-  definition: |
-    openapi: "3.0.0"
-    info:
-        title: security-champion-api-api
+    - api:default/security-champion-api-api
+  system: system:default/utviklerportal


### PR DESCRIPTION
catalog-info.yaml now includes fewer entities

        Removed entities:
        name: security-champion-api-api, kind: API

        
        

        All entities in catalog-info.yaml:
        name: security-champion-service, kind: Component 
        
        

 This PR was created using the Catalog Creator plugin in Backstage.