### PR TITLE
Update eclipse-temurin base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=eclipse-temurin:24.0.2_12-jdk-alpine-3.22
-ARG IMAGE=eclipse-temurin:25.0.1_8-jre-alpine-3.23
+ARG IMAGE=eclipse-temurin:25.0.2_10-jre-alpine-3.23
 
 FROM ${BUILD_IMAGE} AS build
 COPY . .

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("jvm") version "2.2.10"
     kotlin("plugin.spring") version "2.2.10"
-    id("org.springframework.boot") version "3.5.7"
+    id("org.springframework.boot") version "3.5.11"
     id("io.spring.dependency-management") version "1.1.7"
 }
 


### PR DESCRIPTION
# Bakgrunn🔒

`eclipse-temurin:25.0.2_10-jre-alpine-3.23` har 21 sårbarheter

# Løsning🔑

Oppdatere til `eclipse-temurin:25.0.2_10-jre-alpine-3.23` som har 4 sårbarheter