### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,8 +10,8 @@ spec:
   lifecycle: production
   owner: skvis
   providesApis:
-    - security-champion-api-api
-  system: utviklerportal
+    - api:default/security-champion-api-api
+  system: system:default/utviklerportal
 
 ---
 apiVersion: backstage.io/v1alpha1
@@ -29,3 +29,13 @@ spec:
     openapi: "3.0.0"
     info:
         title: security-champion-api-api
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: test
+  title: test123
+spec:
+  type: bundle
+  owner: group:default/skvis


### PR DESCRIPTION
catalog-info.yaml now includes more entities

        
        

        Added entities:
        name: test, kind: Domain

        All entities in catalog-info.yaml:
        name: security-champion-service, kind: Component
        name: security-champion-api-api, kind: API
        name: test, kind: Domain 
        
        

 This PR was created using the Catalog Creator plugin in Backstage.