### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,20 +1,4 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: security-champion-service
-  title: security champion service
-  tags:
-    - internal
-spec:
-  type: service
-  lifecycle: production
-  owner: skvis
-  providesApis:
-    - security-champion-api-api
-  system: utviklerportal
-
----
-apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: security-champion-api-api


### PR DESCRIPTION
Removes Security Champion and repo resource from catalog-info.yaml which is no longer in use