### PR TITLE
Use docker hardened images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+registries:
+  dockerhub-hardened-images:
+    type: docker-registry
+    url: https://dhi.io
+    username: ${{ secrets.DOCKERHUB_USERNAME }}
+    password: ${{ secrets.DOCKERHUB_TOKEN }}
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    registries:
+      - dockerhub-hardened-images
+

--- a/.github/workflows/build-deploy-security-champion-api.yml
+++ b/.github/workflows/build-deploy-security-champion-api.yml
@@ -97,6 +97,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to dhi.io
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.0
+        with:
+          registry: dhi.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-deploy-security-champion-api.yml
+++ b/.github/workflows/build-deploy-security-champion-api.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '25'
           architecture: 'x64'
 
       - name: Setup Gradle

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# HEALTHCHECK not defined, håndteres av SKIP
+DS-0026

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,18 @@
-ARG BUILD_IMAGE=eclipse-temurin:24.0.2_12-jdk-alpine-3.22
-ARG IMAGE=eclipse-temurin:25.0.2_10-jre-alpine-3.23
+# To update: docker buildx imagetools inspect dhi.io/eclipse-temurin:25-jdk-alpine3.24-dev
+ARG BUILD_IMAGE=dhi.io/eclipse-temurin:25-jdk-alpine3.24-dev@sha256:8f1e944fe65a7120dedf30a0754c743f211701babced9625b9ed5c9cddb52b44
+# To update: docker buildx imagetools inspect dhi.io/eclipse-temurin:25-alpine3.24
+ARG IMAGE=dhi.io/eclipse-temurin:25-alpine3.24@sha256:cbd182208579d29ec12007e7c570e72b57eff5353c69f6fa86352bf65469a222
 
 FROM ${BUILD_IMAGE} AS build
+WORKDIR /src
 COPY . .
-RUN ./gradlew build -x test
+RUN ./gradlew bootJar
 
 FROM ${IMAGE}
-# Update package index and upgrade libexpat to a specific version
-RUN apk upgrade --no-cache # && apk add --no-cache libexpat=2.7.0-r0
 
-RUN mkdir /app
 EXPOSE 8080 8081
-RUN adduser -D user && chown -R user /app
 WORKDIR /app
-COPY --from=build /build/libs/security-champion-api-0.0.1-SNAPSHOT.jar ./app.jar
 
-
-USER user
+COPY --from=build /src/build/libs/*.jar ./app.jar
+USER nonroot
 ENTRYPOINT ["java","-jar","app.jar"]
-
-# Use the health endpoint of the application to provide information through docker about the health state of the application
-HEALTHCHECK --start-period=30s --interval=5m \
-   CMD wget -O - --quiet --tries=1 http://localhost:8081/actuator/health | grep UP || exit 1
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "2.2.10"
-    kotlin("plugin.spring") version "2.2.10"
-    id("org.springframework.boot") version "3.5.14"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "13.1.0"
 }
@@ -18,7 +18,7 @@ description = "security-champion-api"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(24)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -33,7 +33,6 @@ dependencyManagement {
     }
 }
 
-ext["tomcat.version"] = "10.1.55"
 ext["postgresql.version"] = "42.7.11"
 
 dependencies {
@@ -58,6 +57,7 @@ dependencies {
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,22 @@ dependencyManagement {
     imports {
         mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:$otelInstrumentationVersion")
         mavenBom("com.fasterxml.jackson:jackson-bom:2.21.4") // Fixes CVE-2026-54513
+        mavenBom("tools.jackson:jackson-bom:3.1.5") // Security fix
     }
 }
 
-ext["postgresql.version"] = "42.7.11"
+ext["tomcat.version"] = "11.0.24"
+ext["postgresql.version"] = "42.7.13"
+ext["spring-framework.version"] = "7.0.8" // security fix
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.springframework.data" && requested.name == "spring-data-commons") {
+            useVersion("4.0.6")
+            because("Security fix: upgrade from 4.0.5 to 4.0.6")
+        }
+    }
+}
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")


### PR DESCRIPTION
## Bakgrunn 🔒

Jira: https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?filter=&groupBy=none&selectedIssue=EDSKVIS-1133

Ønsker å bytte ut tidligere base images til Docker Hardened Images for å bl.a. få kontinuerlig patching av sårbarheter, distroless runtime uten shell og pakkebehandler som kjører som `nonroot`.

Se lignende løsning i SMAPI: https://github.com/kartverket/sikkerhetsmetrikker/pull/1015

## Løsning 🔑

- Byttet base images til DHI:
    - **Build**: `dhi.io/eclipse-temurin:25-jdk-alpine3.24-dev` ([link](https://hub.docker.com/hardened-images/catalog/dhi/eclipse-temurin/images/eclipse-temurin%2Falpine-3.24%2Fjdk-25-dev/sha256-e6fcbb1d8eb3dd64cafcd97682479cc1c3580095836f5fbe0df16f92ad796603))
    - **Runtime**: `eclipse-temurin:25-alpine3.24` ([link](https://hub.docker.com/hardened-images/catalog/dhi/eclipse-temurin/images/eclipse-temurin%2Falpine-3.24%2Fjre-25/sha256-bda71a549ac671b6a70bbefd0f5186cf1da2d8bf11299f736800bd83cd564a18))
- Ryddet i Dockerfil
- Innlogging mot `dhi.io` i build-workflowen med `docker/login-action`, pinnet på SHA
- Dependabot-registry for `dhi.io` slik at base image-digestene holdes oppdatert automatisk
- Oppgradert til java 25 og oppdatert avhengigheter